### PR TITLE
Upgrade to miglayout-swing-5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,10 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 
-	<groupId>org.scijava</groupId>
 	<artifactId>scijava-ui-awt</artifactId>
 	<version>0.1.7-SNAPSHOT</version>
 
@@ -92,6 +91,8 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<miglayout-swing.version>5.2</miglayout-swing.version>
 	</properties>
 
 	<dependencies>
@@ -105,8 +106,8 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<!-- TODO: Decide if this is kosher... -->
 			<groupId>com.miglayout</groupId>
-			<artifactId>miglayout</artifactId>
-			<classifier>swing</classifier>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This starts to address the issues raised in https://github.com/scijava/pom-scijava/pull/97.

We need to temporarily pin the version of miglayout to `5.2` in this commit, before we can remove the version property once all components in the SciJava software stack have been updated to use this new version and have been released.